### PR TITLE
Added a few changes to query expressions

### DIFF
--- a/internal/common/maputils/map.go
+++ b/internal/common/maputils/map.go
@@ -8,6 +8,16 @@ func Values[K comparable, T any](ts map[K]T) []T {
 	return values
 }
 
+func MapValues[K comparable, T, U any](ts map[K]T, fn func(t T) U) map[K]U {
+	us := make(map[K]U)
+
+	for k, t := range ts {
+		us[k] = fn(t)
+	}
+
+	return us
+}
+
 func MapValuesWithError[K comparable, T, U any](ts map[K]T, fn func(t T) (U, error)) (map[K]U, error) {
 	us := make(map[K]U)
 

--- a/internal/common/sliceutils/map.go
+++ b/internal/common/sliceutils/map.go
@@ -39,3 +39,22 @@ func Filter[T any](ts []T, fn func(t T) bool) []T {
 	}
 	return us
 }
+
+func FindFirst[T any](ts []T, fn func(t T) bool) (returnedT T, found bool) {
+	for _, t := range ts {
+		if fn(t) {
+			return t, true
+		}
+	}
+	return returnedT, false
+}
+
+func FindLast[T any](ts []T, fn func(t T) bool) (returnedT T, found bool) {
+	for i := len(ts) - 1; i >= 0; i-- {
+		t := ts[i]
+		if fn(t) {
+			return t, true
+		}
+	}
+	return returnedT, false
+}

--- a/internal/dynamo-browse/controllers/scripts.go
+++ b/internal/dynamo-browse/controllers/scripts.go
@@ -182,6 +182,9 @@ func (s *sessionImpl) Query(ctx context.Context, query string, opts scriptmanage
 	if opts.ValuePlaceholders != nil {
 		expr = expr.WithValueParams(opts.ValuePlaceholders)
 	}
+	if opts.IndexName != "" {
+		expr = expr.WithIndex(opts.IndexName)
+	}
 
 	// Get the table info
 	var tableInfo *models.TableInfo

--- a/internal/dynamo-browse/controllers/tablewrite.go
+++ b/internal/dynamo-browse/controllers/tablewrite.go
@@ -274,12 +274,17 @@ func (twc *TableWriteController) DeleteAttribute(idx int, key string) tea.Msg {
 	}
 
 	if err := twc.state.withResultSetReturningError(func(set *models.ResultSet) error {
-		err := path.DeleteAttribute(set.Items()[idx])
-		if err != nil {
+		if err := applyToMarkedItems(set, idx, func(idx int, item models.Item) error {
+			if err := path.DeleteAttribute(set.Items()[idx]); err != nil {
+				return err
+			}
+
+			set.SetDirty(idx, true)
+			return nil
+		}); err != nil {
 			return err
 		}
 
-		set.SetDirty(idx, true)
 		set.RefreshColumns()
 		return nil
 	}); err != nil {

--- a/internal/dynamo-browse/models/itemtype.go
+++ b/internal/dynamo-browse/models/itemtype.go
@@ -8,4 +8,6 @@ const (
 	NumberItemType ItemType = "N"
 	BoolItemType   ItemType = "BOOL"
 	NullItemType   ItemType = "NULL"
+
+	ExprValueItemType ItemType = "exprvalue"
 )

--- a/internal/dynamo-browse/models/queryexpr/ast.go
+++ b/internal/dynamo-browse/models/queryexpr/ast.go
@@ -38,9 +38,15 @@ type astIn struct {
 }
 
 type astComparisonOp struct {
-	Ref   *astEqualityOp `parser:"@@"`
-	Op    string         `parser:"( @('<' | '<=' | '>' | '>=')"`
-	Value *astEqualityOp `parser:"@@ )?"`
+	Ref   *astBetweenOp `parser:"@@"`
+	Op    string        `parser:"( @('<' | '<=' | '>' | '>=')"`
+	Value *astBetweenOp `parser:"@@ )?"`
+}
+
+type astBetweenOp struct {
+	Ref  *astEqualityOp `parser:"@@"`
+	From *astEqualityOp `parser:"( 'between' @@ "`
+	To   *astEqualityOp `parser:" 'and' @@ )?"`
 }
 
 type astEqualityOp struct {

--- a/internal/dynamo-browse/models/queryexpr/ast.go
+++ b/internal/dynamo-browse/models/queryexpr/ast.go
@@ -172,6 +172,10 @@ func (a *astExpr) calcQuery(ctx *evalContext, info *models.TableInfo, preferredI
 	}
 	if len(queryPlans) == 1 {
 		return queryPlans[0], nil
+	} else if len(queryPlans) == 0 {
+		return nil, NoPlausiblePlanWithIndexError{
+			PreferredIndex: preferredIndex,
+		}
 	}
 
 	return nil, MultiplePlansWithIndexError{

--- a/internal/dynamo-browse/models/queryexpr/ast.go
+++ b/internal/dynamo-browse/models/queryexpr/ast.go
@@ -70,7 +70,6 @@ type astIsOp struct {
 type astSubRef struct {
 	Ref     *astFunctionCall `parser:"@@"`
 	SubRefs []*astSubRefType `parser:"@@*"`
-	//Quals []string `parser:"('.' @Ident)*"`
 }
 
 type astSubRefType struct {

--- a/internal/dynamo-browse/models/queryexpr/atom.go
+++ b/internal/dynamo-browse/models/queryexpr/atom.go
@@ -1,7 +1,6 @@
 package queryexpr
 
 import (
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/lmika/audax/internal/dynamo-browse/models"
 	"github.com/pkg/errors"
 )
@@ -21,14 +20,14 @@ func (a *astAtom) evalToIR(ctx *evalContext, info *models.TableInfo) (irAtom, er
 	return nil, errors.New("unhandled atom case")
 }
 
-func (a *astAtom) rightOperandDynamoValue() (types.AttributeValue, error) {
-	switch {
-	case a.Literal != nil:
-		return a.Literal.dynamoValue()
-	}
-
-	return nil, errors.New("unhandled atom case")
-}
+//func (a *astAtom) rightOperandDynamoValue() (types.AttributeValue, error) {
+//	switch {
+//	case a.Literal != nil:
+//		return a.Literal.dynamoValue()
+//	}
+//
+//	return nil, errors.New("unhandled atom case")
+//}
 
 func (a *astAtom) unqualifiedName() (string, bool) {
 	switch {
@@ -39,12 +38,12 @@ func (a *astAtom) unqualifiedName() (string, bool) {
 	return "", false
 }
 
-func (a *astAtom) evalItem(ctx *evalContext, item models.Item) (types.AttributeValue, error) {
+func (a *astAtom) evalItem(ctx *evalContext, item models.Item) (exprValue, error) {
 	switch {
 	case a.Ref != nil:
 		return a.Ref.evalItem(ctx, item)
 	case a.Literal != nil:
-		return a.Literal.dynamoValue()
+		return a.Literal.exprValue()
 	case a.Placeholder != nil:
 		return a.Placeholder.evalItem(ctx, item)
 	case a.Paren != nil:
@@ -66,7 +65,7 @@ func (a *astAtom) canModifyItem(ctx *evalContext, item models.Item) bool {
 	return false
 }
 
-func (a *astAtom) setEvalItem(ctx *evalContext, item models.Item, value types.AttributeValue) error {
+func (a *astAtom) setEvalItem(ctx *evalContext, item models.Item, value exprValue) error {
 	switch {
 	case a.Ref != nil:
 		return a.Ref.setEvalItem(ctx, item, value)

--- a/internal/dynamo-browse/models/queryexpr/atom.go
+++ b/internal/dynamo-browse/models/queryexpr/atom.go
@@ -20,15 +20,6 @@ func (a *astAtom) evalToIR(ctx *evalContext, info *models.TableInfo) (irAtom, er
 	return nil, errors.New("unhandled atom case")
 }
 
-//func (a *astAtom) rightOperandDynamoValue() (types.AttributeValue, error) {
-//	switch {
-//	case a.Literal != nil:
-//		return a.Literal.dynamoValue()
-//	}
-//
-//	return nil, errors.New("unhandled atom case")
-//}
-
 func (a *astAtom) unqualifiedName() (string, bool) {
 	switch {
 	case a.Ref != nil:

--- a/internal/dynamo-browse/models/queryexpr/between.go
+++ b/internal/dynamo-browse/models/queryexpr/between.go
@@ -1,0 +1,96 @@
+package queryexpr
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/lmika/audax/internal/dynamo-browse/models"
+)
+
+func (a *astBetweenOp) evalToIR(ctx *evalContext, info *models.TableInfo) (irAtom, error) {
+	leftIR, err := a.Ref.evalToIR(ctx, info)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.From == nil {
+		return leftIR, nil
+	}
+
+	nameIR, isNameIR := leftIR.(nameIRAtom)
+	if !isNameIR {
+		return nil, OperandNotANameError(a.Ref.String())
+	}
+
+	fromIR, err := a.From.evalToIR(ctx, info)
+	if err != nil {
+		return nil, err
+	}
+	toIR, err := a.To.evalToIR(ctx, info)
+	if err != nil {
+		return nil, err
+	}
+
+	fromOprIR, isFromOprIR := fromIR.(oprIRAtom)
+	if !isFromOprIR {
+		return nil, OperandNotAnOperandError{}
+	}
+	toOprIR, isToOprIR := toIR.(oprIRAtom)
+	if !isToOprIR {
+		return nil, OperandNotAnOperandError{}
+	}
+
+	return irBetween{name: nameIR, from: fromOprIR, to: toOprIR}, nil
+}
+
+func (a *astBetweenOp) evalItem(ctx *evalContext, item models.Item) (types.AttributeValue, error) {
+	val, err := a.Ref.evalItem(ctx, item)
+	if a.From == nil {
+		return val, err
+	}
+
+	panic("TODO")
+}
+
+func (a *astBetweenOp) canModifyItem(ctx *evalContext, item models.Item) bool {
+	if a.From != nil {
+		return false
+	}
+	return a.Ref.canModifyItem(ctx, item)
+}
+
+func (a *astBetweenOp) setEvalItem(ctx *evalContext, item models.Item, value types.AttributeValue) error {
+	if a.From != nil {
+		return PathNotSettableError{}
+	}
+	return a.Ref.setEvalItem(ctx, item, value)
+}
+
+func (a *astBetweenOp) deleteAttribute(ctx *evalContext, item models.Item) error {
+	if a.From != nil {
+		return PathNotSettableError{}
+	}
+	return a.Ref.deleteAttribute(ctx, item)
+}
+
+func (a *astBetweenOp) String() string {
+	name := a.Ref.String()
+	if a.From != nil {
+		return fmt.Sprintf("%v between %v and %v", name, a.From.String(), a.To.String())
+	}
+	return name
+}
+
+type irBetween struct {
+	name nameIRAtom
+	from oprIRAtom
+	to   oprIRAtom
+}
+
+func (i irBetween) calcQueryForScan(info *models.TableInfo) (expression.ConditionBuilder, error) {
+	nb := i.name.calcName(info)
+	fb := i.from.calcOperand(info)
+	tb := i.to.calcOperand(info)
+
+	return nb.Between(fb, tb), nil
+}

--- a/internal/dynamo-browse/models/queryexpr/boolnot.go
+++ b/internal/dynamo-browse/models/queryexpr/boolnot.go
@@ -2,7 +2,6 @@ package queryexpr
 
 import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/lmika/audax/internal/dynamo-browse/models"
 	"strings"
 )
@@ -20,7 +19,7 @@ func (a *astBooleanNot) evalToIR(ctx *evalContext, tableInfo *models.TableInfo) 
 	return &irBoolNot{atom: irNode}, nil
 }
 
-func (a *astBooleanNot) evalItem(ctx *evalContext, item models.Item) (types.AttributeValue, error) {
+func (a *astBooleanNot) evalItem(ctx *evalContext, item models.Item) (exprValue, error) {
 	val, err := a.Operand.evalItem(ctx, item)
 	if err != nil {
 		return nil, err
@@ -30,7 +29,7 @@ func (a *astBooleanNot) evalItem(ctx *evalContext, item models.Item) (types.Attr
 		return val, nil
 	}
 
-	return &types.AttributeValueMemberBOOL{Value: !isAttributeTrue(val)}, nil
+	return boolExprValue(!isAttributeTrue(val)), nil
 }
 
 func (a *astBooleanNot) canModifyItem(ctx *evalContext, item models.Item) bool {
@@ -40,7 +39,7 @@ func (a *astBooleanNot) canModifyItem(ctx *evalContext, item models.Item) bool {
 	return a.Operand.canModifyItem(ctx, item)
 }
 
-func (a *astBooleanNot) setEvalItem(ctx *evalContext, item models.Item, value types.AttributeValue) error {
+func (a *astBooleanNot) setEvalItem(ctx *evalContext, item models.Item, value exprValue) error {
 	if a.HasNot {
 		return PathNotSettableError{}
 	}

--- a/internal/dynamo-browse/models/queryexpr/builtins.go
+++ b/internal/dynamo-browse/models/queryexpr/builtins.go
@@ -15,20 +15,12 @@ var nativeFuncs = map[string]nativeFunc{
 
 		var l int
 		switch t := args[0].(type) {
-		//case *types.AttributeValueMemberB:
-		//	l = len(t.Value)
 		case stringExprValue:
 			l = len(t)
 		case mappableExprValue:
 			l = t.len()
 		case slicableExprValue:
 			l = t.len()
-		//case *types.AttributeValueMemberSS:
-		//	l = len(t.Value)
-		//case *types.AttributeValueMemberNS:
-		//	l = len(t.Value)
-		//case *types.AttributeValueMemberBS:
-		//	l = len(t.Value)
 		default:
 			return nil, errors.New("cannot take size of arg")
 		}
@@ -76,18 +68,7 @@ var nativeFuncs = map[string]nativeFunc{
 		if !isYNum {
 			return nil, InvalidArgumentTypeError{Name: "_x_add", ArgIndex: 1, Expected: "N"}
 		}
-		//
-		//xNumVal, _, err := big.ParseFloat(xVal.Value, 10, 63, big.ToNearestEven)
-		//if err != nil {
-		//	return nil, err
-		//}
-		//
-		//yNumVal, _, err := big.ParseFloat(yVal.Value, 10, 63, big.ToNearestEven)
-		//if err != nil {
-		//	return nil, err
-		//}
-		//
-		//return &types.AttributeValueMemberN{Value: xNumVal.Add(xNumVal, yNumVal).String()}, nil
+
 		return bigNumExprValue{num: xVal.asBigFloat().Add(xVal.asBigFloat(), yVal.asBigFloat())}, nil
 	},
 

--- a/internal/dynamo-browse/models/queryexpr/builtins.go
+++ b/internal/dynamo-browse/models/queryexpr/builtins.go
@@ -36,4 +36,9 @@ var nativeFuncs = map[string]nativeFunc{
 		}
 		return &types.AttributeValueMemberN{Value: strconv.Itoa(l)}, nil
 	},
+
+	"_x_now": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
+		now := timeSourceFromContext(ctx).now().Unix()
+		return &types.AttributeValueMemberN{Value: strconv.FormatInt(now, 10)}, nil
+	},
 }

--- a/internal/dynamo-browse/models/queryexpr/builtins.go
+++ b/internal/dynamo-browse/models/queryexpr/builtins.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/pkg/errors"
+	"math/big"
 	"strconv"
 )
 
@@ -40,5 +41,32 @@ var nativeFuncs = map[string]nativeFunc{
 	"_x_now": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
 		now := timeSourceFromContext(ctx).now().Unix()
 		return &types.AttributeValueMemberN{Value: strconv.FormatInt(now, 10)}, nil
+	},
+
+	"_x_add": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
+		if len(args) != 2 {
+			return nil, InvalidArgumentNumberError{Name: "_x_add", Expected: 2, Actual: len(args)}
+		}
+
+		xVal, isXNum := args[0].(*types.AttributeValueMemberN)
+		if !isXNum {
+			return nil, InvalidArgumentTypeError{Name: "_x_add", ArgIndex: 0, Expected: "N"}
+		}
+		yVal, isYNum := args[1].(*types.AttributeValueMemberN)
+		if !isYNum {
+			return nil, InvalidArgumentTypeError{Name: "_x_add", ArgIndex: 1, Expected: "N"}
+		}
+
+		xNumVal, _, err := big.ParseFloat(xVal.Value, 10, 63, big.ToNearestEven)
+		if err != nil {
+			return nil, err
+		}
+
+		yNumVal, _, err := big.ParseFloat(yVal.Value, 10, 63, big.ToNearestEven)
+		if err != nil {
+			return nil, err
+		}
+
+		return &types.AttributeValueMemberN{Value: xNumVal.Add(xNumVal, yNumVal).String()}, nil
 	},
 }

--- a/internal/dynamo-browse/models/queryexpr/builtins.go
+++ b/internal/dynamo-browse/models/queryexpr/builtins.go
@@ -2,71 +2,109 @@ package queryexpr
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/pkg/errors"
-	"math/big"
-	"strconv"
 )
 
-type nativeFunc func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error)
+type nativeFunc func(ctx context.Context, args []exprValue) (exprValue, error)
 
 var nativeFuncs = map[string]nativeFunc{
-	"size": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
+	"size": func(ctx context.Context, args []exprValue) (exprValue, error) {
 		if len(args) != 1 {
 			return nil, InvalidArgumentNumberError{Name: "size", Expected: 1, Actual: len(args)}
 		}
 
 		var l int
 		switch t := args[0].(type) {
-		case *types.AttributeValueMemberB:
-			l = len(t.Value)
-		case *types.AttributeValueMemberS:
-			l = len(t.Value)
-		case *types.AttributeValueMemberL:
-			l = len(t.Value)
-		case *types.AttributeValueMemberM:
-			l = len(t.Value)
-		case *types.AttributeValueMemberSS:
-			l = len(t.Value)
-		case *types.AttributeValueMemberNS:
-			l = len(t.Value)
-		case *types.AttributeValueMemberBS:
-			l = len(t.Value)
+		//case *types.AttributeValueMemberB:
+		//	l = len(t.Value)
+		case stringExprValue:
+			l = len(t)
+		case mappableExprValue:
+			l = t.len()
+		case slicableExprValue:
+			l = t.len()
+		//case *types.AttributeValueMemberSS:
+		//	l = len(t.Value)
+		//case *types.AttributeValueMemberNS:
+		//	l = len(t.Value)
+		//case *types.AttributeValueMemberBS:
+		//	l = len(t.Value)
 		default:
 			return nil, errors.New("cannot take size of arg")
 		}
-		return &types.AttributeValueMemberN{Value: strconv.Itoa(l)}, nil
+		return int64ExprValue(l), nil
 	},
 
-	"_x_now": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
+	"range": func(ctx context.Context, args []exprValue) (exprValue, error) {
+		if len(args) != 2 {
+			return nil, InvalidArgumentNumberError{Name: "range", Expected: 2, Actual: len(args)}
+		}
+
+		xVal, isXNum := args[0].(numberableExprValue)
+		if !isXNum {
+			return nil, InvalidArgumentTypeError{Name: "range", ArgIndex: 0, Expected: "N"}
+		}
+		yVal, isYNum := args[1].(numberableExprValue)
+		if !isYNum {
+			return nil, InvalidArgumentTypeError{Name: "range", ArgIndex: 1, Expected: "N"}
+		}
+
+		xInt, _ := xVal.asBigFloat().Int64()
+		yInt, _ := yVal.asBigFloat().Int64()
+		xs := make([]exprValue, 0)
+		for x := xInt; x <= yInt; x++ {
+			xs = append(xs, int64ExprValue(x))
+		}
+		return listExprValue(xs), nil
+	},
+
+	"_x_now": func(ctx context.Context, args []exprValue) (exprValue, error) {
 		now := timeSourceFromContext(ctx).now().Unix()
-		return &types.AttributeValueMemberN{Value: strconv.FormatInt(now, 10)}, nil
+		return int64ExprValue(now), nil
 	},
 
-	"_x_add": func(ctx context.Context, args []types.AttributeValue) (types.AttributeValue, error) {
+	"_x_add": func(ctx context.Context, args []exprValue) (exprValue, error) {
 		if len(args) != 2 {
 			return nil, InvalidArgumentNumberError{Name: "_x_add", Expected: 2, Actual: len(args)}
 		}
 
-		xVal, isXNum := args[0].(*types.AttributeValueMemberN)
+		xVal, isXNum := args[0].(numberableExprValue)
 		if !isXNum {
 			return nil, InvalidArgumentTypeError{Name: "_x_add", ArgIndex: 0, Expected: "N"}
 		}
-		yVal, isYNum := args[1].(*types.AttributeValueMemberN)
+		yVal, isYNum := args[1].(numberableExprValue)
 		if !isYNum {
 			return nil, InvalidArgumentTypeError{Name: "_x_add", ArgIndex: 1, Expected: "N"}
 		}
+		//
+		//xNumVal, _, err := big.ParseFloat(xVal.Value, 10, 63, big.ToNearestEven)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//
+		//yNumVal, _, err := big.ParseFloat(yVal.Value, 10, 63, big.ToNearestEven)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//
+		//return &types.AttributeValueMemberN{Value: xNumVal.Add(xNumVal, yNumVal).String()}, nil
+		return bigNumExprValue{num: xVal.asBigFloat().Add(xVal.asBigFloat(), yVal.asBigFloat())}, nil
+	},
 
-		xNumVal, _, err := big.ParseFloat(xVal.Value, 10, 63, big.ToNearestEven)
-		if err != nil {
-			return nil, err
+	"_x_concat": func(ctx context.Context, args []exprValue) (exprValue, error) {
+		if len(args) != 2 {
+			return nil, InvalidArgumentNumberError{Name: "_x_concat", Expected: 2, Actual: len(args)}
 		}
 
-		yNumVal, _, err := big.ParseFloat(yVal.Value, 10, 63, big.ToNearestEven)
-		if err != nil {
-			return nil, err
+		xVal, isXNum := args[0].(stringableExprValue)
+		if !isXNum {
+			return nil, InvalidArgumentTypeError{Name: "_x_concat", ArgIndex: 0, Expected: "S"}
+		}
+		yVal, isYNum := args[1].(stringableExprValue)
+		if !isYNum {
+			return nil, InvalidArgumentTypeError{Name: "_x_concat", ArgIndex: 1, Expected: "S"}
 		}
 
-		return &types.AttributeValueMemberN{Value: xNumVal.Add(xNumVal, yNumVal).String()}, nil
+		return stringExprValue(xVal.asString() + yVal.asString()), nil
 	},
 }

--- a/internal/dynamo-browse/models/queryexpr/context.go
+++ b/internal/dynamo-browse/models/queryexpr/context.go
@@ -1,0 +1,27 @@
+package queryexpr
+
+import (
+	"context"
+	"time"
+)
+
+type timeSource interface {
+	now() time.Time
+}
+
+type defaultTimeSource struct{}
+
+func (tds defaultTimeSource) now() time.Time {
+	return time.Now()
+}
+
+type timeSourceContextKeyType struct{}
+
+var timeSourceContextKey = timeSourceContextKeyType{}
+
+func timeSourceFromContext(ctx context.Context) timeSource {
+	if tts, ok := ctx.Value(timeSourceContextKey).(timeSource); ok {
+		return tts
+	}
+	return defaultTimeSource{}
+}

--- a/internal/dynamo-browse/models/queryexpr/errors.go
+++ b/internal/dynamo-browse/models/queryexpr/errors.go
@@ -98,6 +98,14 @@ func (n InvalidTypeForIsError) Error() string {
 	return "invalid type for 'is': " + n.TypeName
 }
 
+type InvalidTypeForBetweenError struct {
+	TypeName string
+}
+
+func (n InvalidTypeForBetweenError) Error() string {
+	return "invalid type for 'between': " + n.TypeName
+}
+
 type InvalidArgumentNumberError struct {
 	Name     string
 	Expected int

--- a/internal/dynamo-browse/models/queryexpr/errors.go
+++ b/internal/dynamo-browse/models/queryexpr/errors.go
@@ -137,3 +137,20 @@ type ValueNotUsableAsASubref struct {
 func (e ValueNotUsableAsASubref) Error() string {
 	return "value cannot be used as a subref"
 }
+
+type MultiplePlansWithIndexError struct {
+	PossibleIndices []string
+}
+
+func (e MultiplePlansWithIndexError) Error() string {
+	return fmt.Sprintf("multiple plans with index found. Specify index or scan with 'using' clause: possible indices are %v", e.PossibleIndices)
+}
+
+type NoPlausiblePlanWithIndexError struct {
+	PreferredIndex  string
+	PossibleIndices []string
+}
+
+func (e NoPlausiblePlanWithIndexError) Error() string {
+	return fmt.Sprintf("no plan with index '%v' found: possible indices are %v", e.PreferredIndex, e.PossibleIndices)
+}

--- a/internal/dynamo-browse/models/queryexpr/errors.go
+++ b/internal/dynamo-browse/models/queryexpr/errors.go
@@ -108,6 +108,16 @@ func (e InvalidArgumentNumberError) Error() string {
 	return fmt.Sprintf("function '%v' expected %v args but received %v", e.Name, e.Expected, e.Actual)
 }
 
+type InvalidArgumentTypeError struct {
+	Name     string
+	ArgIndex int
+	Expected string
+}
+
+func (e InvalidArgumentTypeError) Error() string {
+	return fmt.Sprintf("function '%v' expected arg %v to be of type %v", e.Name, e.ArgIndex, e.Expected)
+}
+
 type UnrecognisedFunctionError struct {
 	Name string
 }

--- a/internal/dynamo-browse/models/queryexpr/expr.go
+++ b/internal/dynamo-browse/models/queryexpr/expr.go
@@ -19,6 +19,9 @@ type QueryExpr struct {
 	index  string
 	names  map[string]string
 	values map[string]types.AttributeValue
+
+	// tests fields only
+	timeSource timeSource
 }
 
 type serializedExpr struct {
@@ -253,6 +256,7 @@ type evalContext struct {
 	nameLookup        func(string) (string, bool)
 	valuePlaceholders map[string]types.AttributeValue
 	valueLookup       func(string) (types.AttributeValue, bool)
+	timeSource        timeSource
 }
 
 func (ec *evalContext) lookupName(name string) (string, bool) {
@@ -279,4 +283,11 @@ func (ec *evalContext) lookupValue(name string) (types.AttributeValue, bool) {
 	}
 
 	return nil, false
+}
+
+func (ec *evalContext) getTimeSource() timeSource {
+	if ts := ec.timeSource; ts != nil {
+		return ts
+	}
+	return defaultTimeSource{}
 }

--- a/internal/dynamo-browse/models/queryexpr/expr.go
+++ b/internal/dynamo-browse/models/queryexpr/expr.go
@@ -187,7 +187,14 @@ func (md *QueryExpr) Plan(tableInfo *models.TableInfo) (*models.QueryExecutionPl
 }
 
 func (md *QueryExpr) EvalItem(item models.Item) (types.AttributeValue, error) {
-	return md.ast.evalItem(md.evalContext(), item)
+	val, err := md.ast.evalItem(md.evalContext(), item)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, nil
+	}
+	return val.asAttributeValue(), nil
 }
 
 func (md *QueryExpr) DeleteAttribute(item models.Item) error {
@@ -195,7 +202,11 @@ func (md *QueryExpr) DeleteAttribute(item models.Item) error {
 }
 
 func (md *QueryExpr) SetEvalItem(item models.Item, newValue types.AttributeValue) error {
-	return md.ast.setEvalItem(md.evalContext(), item, newValue)
+	val, err := newExprValueFromAttributeValue(newValue)
+	if err != nil {
+		return err
+	}
+	return md.ast.setEvalItem(md.evalContext(), item, val)
 }
 
 func (md *QueryExpr) IsModifiablePath(item models.Item) bool {

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -516,7 +516,9 @@ func TestQueryExpr_EvalItem(t *testing.T) {
 			{expr: "three between one and five", expected: &types.AttributeValueMemberBOOL{Value: true}},
 			{expr: "three between 10 and 15", expected: &types.AttributeValueMemberBOOL{Value: false}},
 			{expr: "three between 1 and 2", expected: &types.AttributeValueMemberBOOL{Value: false}},
-			{expr: "8 between five and 10", expected: &types.AttributeValueMemberBOOL{Value: false}},
+			{expr: "8 between five and 10", expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: "three between 1 and 3", expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: "three between 3 and 5", expected: &types.AttributeValueMemberBOOL{Value: true}},
 
 			{expr: `"e" between "a" and "z"`, expected: &types.AttributeValueMemberBOOL{Value: true}},
 			{expr: `"eee" between "aaa" and "zzz"`, expected: &types.AttributeValueMemberBOOL{Value: true}},

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -120,6 +120,13 @@ func TestModExpr_Query(t *testing.T) {
 				exprNameIsString(0, 0, "pk", "prefix"),
 				exprNameIsNumber(1, 1, "sk", "100"),
 			),
+			scanCase("when request pk is equals and sk is greater or equal to",
+				`pk="prefix" and sk between 100 and 200`,
+				`(#0 = :0) AND (#1 BETWEEN :1 AND :2)`,
+				exprNameIsString(0, 0, "pk", "prefix"),
+				exprNameIsNumber(1, 1, "sk", "100"),
+				exprValueIsNumber(2, "200"),
+			),
 
 			scanCase("with placeholders",
 				`:partition=$valuePrefix and :sort=$valueAnother`,

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -426,6 +426,14 @@ func TestModExpr_Query(t *testing.T) {
 			assert.True(t, plan.CanQuery)
 			assert.Equal(t, "with-apples-and-oranges", plan.IndexName)
 		})
+
+		t.Run("should return error if the chosen index can't be used", func(t *testing.T) {
+			modExpr, err := queryexpr.Parse(`apples="this" using index("with-missing")`)
+			assert.NoError(t, err)
+
+			_, err = modExpr.Plan(tableInfo)
+			assert.Error(t, err)
+		})
 	})
 }
 

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -471,7 +471,9 @@ func TestQueryExpr_EvalItem(t *testing.T) {
 					&types.AttributeValueMemberN{Value: "7"},
 				},
 			},
+			"one":   &types.AttributeValueMemberN{Value: "1"},
 			"three": &types.AttributeValueMemberN{Value: "3"},
+			"five":  &types.AttributeValueMemberN{Value: "5"},
 		}
 	)
 
@@ -508,6 +510,17 @@ func TestQueryExpr_EvalItem(t *testing.T) {
 			{expr: "three >= 2", expected: &types.AttributeValueMemberBOOL{Value: true}},
 			{expr: "three < 2", expected: &types.AttributeValueMemberBOOL{Value: false}},
 			{expr: "three <= 2", expected: &types.AttributeValueMemberBOOL{Value: false}},
+
+			// Between
+			{expr: "three between 1 and 5", expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: "three between one and five", expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: "three between 10 and 15", expected: &types.AttributeValueMemberBOOL{Value: false}},
+			{expr: "three between 1 and 2", expected: &types.AttributeValueMemberBOOL{Value: false}},
+			{expr: "8 between five and 10", expected: &types.AttributeValueMemberBOOL{Value: false}},
+
+			{expr: `"e" between "a" and "z"`, expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: `"eee" between "aaa" and "zzz"`, expected: &types.AttributeValueMemberBOOL{Value: true}},
+			{expr: `"e" between "between" and "beyond"`, expected: &types.AttributeValueMemberBOOL{Value: false}},
 
 			// In
 			{expr: "three in (2, 3, 4, 5)", expected: &types.AttributeValueMemberBOOL{Value: true}},

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -238,6 +238,13 @@ func TestModExpr_Query(t *testing.T) {
 				exprNameIsString(0, 0, "pk", "prefix"),
 			),
 
+			scanCase("with between", `pk between "a" and "z"`,
+				`#0 BETWEEN :0 AND :1`,
+				exprName(0, "pk"),
+				exprValueIsString(0, "a"),
+				exprValueIsString(1, "z"),
+			),
+
 			scanCase("with in", `pk in ("alpha", "bravo", "charlie")`,
 				`#0 IN (:0, :1, :2)`,
 				exprName(0, "pk"),

--- a/internal/dynamo-browse/models/queryexpr/expr_test.go
+++ b/internal/dynamo-browse/models/queryexpr/expr_test.go
@@ -164,6 +164,13 @@ func TestModExpr_Query(t *testing.T) {
 				exprNameIsString(0, 0, "color", "yellow"),
 				exprNameIsString(1, 1, "shade", "dark"),
 			),
+
+			// Function calls
+			scanCase("use the value of fn call in query",
+				`pk = _x_concat("Hello ", "world")`,
+				`#0 = :0`,
+				exprNameIsString(0, 0, "pk", "Hello world"),
+			),
 		}
 
 		for _, scenario := range scenarios {

--- a/internal/dynamo-browse/models/queryexpr/fncall.go
+++ b/internal/dynamo-browse/models/queryexpr/fncall.go
@@ -64,40 +64,6 @@ func (a *astFunctionCall) evalToIR(ctx *evalContext, info *models.TableInfo) (ir
 	}
 
 	return irValue{value: val}, nil
-
-	/*
-		case "range":
-			if len(irNodes) != 2 {
-				return nil, InvalidArgumentNumberError{Name: "range", Expected: 2, Actual: len(irNodes)}
-			}
-
-			// TEMP
-			fromVal := irNodes[0].(valueIRAtom).goValue().(int64)
-			toVal := irNodes[1].(valueIRAtom).goValue().(int64)
-			return irRangeFn{fromVal, toVal}, nil
-		case "file":
-			if len(irNodes) != 1 {
-				return nil, InvalidArgumentNumberError{Name: "file", Expected: 1, Actual: len(irNodes)}
-			}
-
-			// TEMP
-			fileName := irNodes[0].(valueIRAtom).goValue().(string)
-
-			bytes, err := os.ReadFile(fileName)
-			if err != nil {
-				return nil, err
-			}
-
-			lines := strings.Split(string(bytes), "\n")
-			lines = sliceutils.Map(lines, strings.TrimSpace)
-			lines = sliceutils.Filter(lines, func(s string) bool { return s != "" })
-			log.Printf("lines = %v", lines)
-
-			linesAsAny := sliceutils.Map[string, any](lines, func(s string) any { return s })
-			return multiValueFnResult{items: linesAsAny}, nil
-		}
-	*/
-	//return nil, UnrecognisedFunctionError{Name: nameIr.keyName()}
 }
 
 func (a *astFunctionCall) evalItem(ctx *evalContext, item models.Item) (exprValue, error) {

--- a/internal/dynamo-browse/models/queryexpr/fncall.go
+++ b/internal/dynamo-browse/models/queryexpr/fncall.go
@@ -96,7 +96,8 @@ func (a *astFunctionCall) evalItem(ctx *evalContext, item models.Item) (types.At
 		return nil, err
 	}
 
-	return fn(context.Background(), args)
+	cCtx := context.WithValue(context.Background(), timeSourceContextKey, ctx.timeSource)
+	return fn(cCtx, args)
 }
 
 func (a *astFunctionCall) canModifyItem(ctx *evalContext, item models.Item) bool {

--- a/internal/dynamo-browse/models/queryexpr/helpers_test.go
+++ b/internal/dynamo-browse/models/queryexpr/helpers_test.go
@@ -1,0 +1,16 @@
+package queryexpr
+
+import (
+	"time"
+)
+
+type testTimeSource time.Time
+
+func (tds testTimeSource) now() time.Time {
+	return time.Time(tds)
+}
+
+func (a *QueryExpr) WithTestTimeSource(timeNow time.Time) *QueryExpr {
+	a.timeSource = testTimeSource(timeNow)
+	return a
+}

--- a/internal/dynamo-browse/models/queryexpr/in.go
+++ b/internal/dynamo-browse/models/queryexpr/in.go
@@ -82,13 +82,6 @@ func (a *astIn) evalToIR(ctx *evalContext, info *models.TableInfo) (irAtom, erro
 			}
 
 			ir = irIn{name: nameIR, values: []oprIRAtom{t}}
-		//case multiValueIRAtom:
-		//	nameIR, isNameIR := leftIR.(irNamePath)
-		//	if !isNameIR {
-		//		return nil, OperandNotANameError(a.Ref.String())
-		//	}
-		//
-		//	ir = irLiteralValues{name: nameIR, values: t}
 		default:
 			return nil, OperandNotAnOperandError{}
 		}
@@ -155,43 +148,6 @@ func (a *astIn) evalItem(ctx *evalContext, item models.Item) (exprValue, error) 
 				}
 			}
 			return boolExprValue(false), nil
-		//case *types.AttributeValueMemberSS:
-		//	str, canToStr := attrutils.AttributeToString(val)
-		//	if !canToStr {
-		//		return boolExprValue(false), nil
-		//	}
-		//
-		//	for _, listItem := range t.Value {
-		//		if str != listItem {
-		//			return boolExprValue(false), nil
-		//		}
-		//	}
-		//	return boolExprValue(true), nil
-		//case *types.AttributeValueMemberBS:
-		//	b, isB := val.(*types.AttributeValueMemberB)
-		//	if !isB {
-		//		return boolExprValue(false), nil
-		//	}
-		//
-		//	for _, listItem := range t.Value {
-		//		if !bytes.Equal(b.Value, listItem) {
-		//			return boolExprValue(false), nil
-		//		}
-		//	}
-		//	return boolExprValue(true), nil
-		//case *types.AttributeValueMemberNS:
-		//	n, isN := val.(*types.AttributeValueMemberN)
-		//	if !isN {
-		//		return boolExprValue(false), nil
-		//	}
-		//
-		//	for _, listItem := range t.Value {
-		//		// TODO: this is not actually right
-		//		if n.Value != listItem {
-		//			return boolExprValue(false), nil
-		//		}
-		//	}
-		//	return boolExprValue(true), nil
 		case mappableExprValue:
 			str, canToStr := val.(stringableExprValue)
 			if !canToStr {

--- a/internal/dynamo-browse/models/queryexpr/ir.go
+++ b/internal/dynamo-browse/models/queryexpr/ir.go
@@ -36,12 +36,12 @@ type nameIRAtom interface {
 
 type valueIRAtom interface {
 	oprIRAtom
-	goValue() any
+	exprValue() exprValue
 }
 
-type multiValueIRAtom interface {
-	calcGoValues(info *models.TableInfo) ([]any, error)
-}
+//type multiValueIRAtom interface {
+//	calcGoValues(info *models.TableInfo) ([]any, error)
+//}
 
 func canExecuteAsQuery(ir irAtom, qci *queryCalcInfo) bool {
 	queryable, isQuearyable := ir.(queryableIRAtom)

--- a/internal/dynamo-browse/models/queryexpr/ir.go
+++ b/internal/dynamo-browse/models/queryexpr/ir.go
@@ -39,10 +39,6 @@ type valueIRAtom interface {
 	exprValue() exprValue
 }
 
-//type multiValueIRAtom interface {
-//	calcGoValues(info *models.TableInfo) ([]any, error)
-//}
-
 func canExecuteAsQuery(ir irAtom, qci *queryCalcInfo) bool {
 	queryable, isQuearyable := ir.(queryableIRAtom)
 	if !isQuearyable {

--- a/internal/dynamo-browse/models/queryexpr/subref.go
+++ b/internal/dynamo-browse/models/queryexpr/subref.go
@@ -139,20 +139,6 @@ func (r *astSubRef) deleteAttribute(ctx *evalContext, item models.Item) error {
 		return err
 	}
 
-	/*
-		for i, key := range r.Quals {
-			mapItem, isMapItem := parentItem.(*types.AttributeValueMemberM)
-			if !isMapItem {
-				return PathNotSettableError{}
-			}
-
-			if isLast := i == len(r.Quals)-1; isLast {
-				delete(mapItem.Value, key)
-			} else {
-				parentItem = mapItem.Value[key]
-			}
-		}
-	*/
 	if len(r.SubRefs) > 1 {
 		parentItem, err = r.evalSubRefs(ctx, item, parentItem, r.SubRefs[0:len(r.SubRefs)-1])
 		if err != nil {

--- a/internal/dynamo-browse/models/queryexpr/types.go
+++ b/internal/dynamo-browse/models/queryexpr/types.go
@@ -1,1 +1,339 @@
 package queryexpr
+
+import (
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/lmika/audax/internal/common/maputils"
+	"github.com/lmika/audax/internal/common/sliceutils"
+	"github.com/pkg/errors"
+	"math/big"
+	"strconv"
+)
+
+type exprValue interface {
+	asGoValue() any
+	asAttributeValue() types.AttributeValue
+}
+
+type stringableExprValue interface {
+	exprValue
+	asString() string
+}
+
+type numberableExprValue interface {
+	exprValue
+	asBigFloat() *big.Float
+	asInt() int64
+}
+
+type slicableExprValue interface {
+	exprValue
+	len() int
+	valueAt(idx int) (exprValue, error)
+}
+
+type modifiableSliceExprValue interface {
+	setValueAt(idx int, value exprValue)
+	deleteValueAt(idx int)
+}
+
+type mappableExprValue interface {
+	len() int
+	hasKey(name string) bool
+	valueOf(name string) (exprValue, error)
+}
+
+type modifiableMapExprValue interface {
+	setValueOf(name string, value exprValue)
+	deleteValueOf(name string)
+}
+
+func buildExpressionFromValue(ev exprValue) expression.ValueBuilder {
+	return expression.Value(ev)
+}
+
+func newExprValueFromAttributeValue(ev types.AttributeValue) (exprValue, error) {
+	if ev == nil {
+		return nil, nil
+	}
+
+	switch xVal := ev.(type) {
+	case *types.AttributeValueMemberS:
+		return stringExprValue(xVal.Value), nil
+	case *types.AttributeValueMemberN:
+		xNumVal, _, err := big.ParseFloat(xVal.Value, 10, 63, big.ToNearestEven)
+		if err != nil {
+			return nil, err
+		}
+		return bigNumExprValue{num: xNumVal}, nil
+	case *types.AttributeValueMemberBOOL:
+		return boolExprValue(xVal.Value), nil
+	case *types.AttributeValueMemberNULL:
+		return nullExprValue{}, nil
+	case *types.AttributeValueMemberL:
+		return listProxyValue{list: xVal}, nil
+	case *types.AttributeValueMemberM:
+		return mapProxyValue{mapValue: xVal}, nil
+	case *types.AttributeValueMemberSS:
+		return stringSetProxyValue{stringSet: xVal}, nil
+	case *types.AttributeValueMemberNS:
+		return numberSetProxyValue{numberSet: xVal}, nil
+	}
+	return nil, errors.New("cannot convert to expr value")
+}
+
+type stringExprValue string
+
+func (s stringExprValue) asGoValue() any {
+	return string(s)
+}
+
+func (s stringExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberS{Value: string(s)}
+}
+
+func (s stringExprValue) asString() string {
+	return string(s)
+}
+
+type int64ExprValue int64
+
+func (i int64ExprValue) asGoValue() any {
+	return int(i)
+}
+
+func (i int64ExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberN{Value: strconv.Itoa(int(i))}
+}
+
+func (i int64ExprValue) asInt() int64 {
+	return int64(i)
+}
+
+func (i int64ExprValue) asBigFloat() *big.Float {
+	var f big.Float
+	f.SetInt64(int64(i))
+	return &f
+}
+
+type bigNumExprValue struct {
+	num *big.Float
+}
+
+func (i bigNumExprValue) asGoValue() any {
+	return i.num
+}
+
+func (i bigNumExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberN{Value: i.num.String()}
+}
+
+func (i bigNumExprValue) asInt() int64 {
+	x, _ := i.num.Int64()
+	return x
+}
+
+func (i bigNumExprValue) asBigFloat() *big.Float {
+	return i.num
+}
+
+type boolExprValue bool
+
+func (b boolExprValue) asGoValue() any {
+	return bool(b)
+}
+
+func (b boolExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberBOOL{Value: bool(b)}
+}
+
+type nullExprValue struct{}
+
+func (b nullExprValue) asGoValue() any {
+	return nil
+}
+
+func (b nullExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberNULL{Value: true}
+}
+
+type listExprValue []exprValue
+
+func (bs listExprValue) asGoValue() any {
+	return sliceutils.Map(bs, func(t exprValue) any {
+		return t.asGoValue()
+	})
+}
+
+func (bs listExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberL{Value: sliceutils.Map(bs, func(t exprValue) types.AttributeValue {
+		return t.asAttributeValue()
+	})}
+}
+
+func (bs listExprValue) len() int {
+	return len(bs)
+}
+
+func (bs listExprValue) valueAt(i int) (exprValue, error) {
+	return bs[i], nil
+}
+
+type mapExprValue map[string]exprValue
+
+func (bs mapExprValue) asGoValue() any {
+	return maputils.MapValues(bs, func(t exprValue) any {
+		return t.asGoValue()
+	})
+}
+
+func (bs mapExprValue) asAttributeValue() types.AttributeValue {
+	return &types.AttributeValueMemberM{Value: maputils.MapValues(bs, func(t exprValue) types.AttributeValue {
+		return t.asAttributeValue()
+	})}
+}
+
+func (bs mapExprValue) len() int {
+	return len(bs)
+}
+
+func (bs mapExprValue) hasKey(name string) bool {
+	_, ok := bs[name]
+	return ok
+}
+
+func (bs mapExprValue) valueOf(name string) (exprValue, error) {
+	return bs[name], nil
+}
+
+type listProxyValue struct {
+	list *types.AttributeValueMemberL
+}
+
+func (bs listProxyValue) asGoValue() any {
+	panic("TODO")
+}
+
+func (bs listProxyValue) asAttributeValue() types.AttributeValue {
+	return bs.list
+}
+
+func (bs listProxyValue) len() int {
+	return len(bs.list.Value)
+}
+
+func (bs listProxyValue) valueAt(i int) (exprValue, error) {
+	return newExprValueFromAttributeValue(bs.list.Value[i])
+}
+
+func (bs listProxyValue) setValueAt(i int, newVal exprValue) {
+	bs.list.Value[i] = newVal.asAttributeValue()
+}
+
+func (bs listProxyValue) deleteValueAt(idx int) {
+	newList := append([]types.AttributeValue{}, bs.list.Value[:idx]...)
+	newList = append(newList, bs.list.Value[idx+1:]...)
+	bs.list = &types.AttributeValueMemberL{Value: newList}
+}
+
+type mapProxyValue struct {
+	mapValue *types.AttributeValueMemberM
+}
+
+func (bs mapProxyValue) asGoValue() any {
+	panic("TODO")
+}
+
+func (bs mapProxyValue) asAttributeValue() types.AttributeValue {
+	return bs.mapValue
+}
+
+func (bs mapProxyValue) len() int {
+	return len(bs.mapValue.Value)
+}
+
+func (bs mapProxyValue) hasKey(name string) bool {
+	_, ok := bs.mapValue.Value[name]
+	return ok
+}
+
+func (bs mapProxyValue) valueOf(name string) (exprValue, error) {
+	return newExprValueFromAttributeValue(bs.mapValue.Value[name])
+}
+
+func (bs mapProxyValue) setValueOf(name string, newVal exprValue) {
+	bs.mapValue.Value[name] = newVal.asAttributeValue()
+}
+
+func (bs mapProxyValue) deleteValueOf(name string) {
+	delete(bs.mapValue.Value, name)
+}
+
+type stringSetProxyValue struct {
+	stringSet *types.AttributeValueMemberSS
+}
+
+func (bs stringSetProxyValue) asGoValue() any {
+	panic("TODO")
+}
+
+func (bs stringSetProxyValue) asAttributeValue() types.AttributeValue {
+	return bs.stringSet
+}
+
+func (bs stringSetProxyValue) len() int {
+	return len(bs.stringSet.Value)
+}
+
+func (bs stringSetProxyValue) valueAt(i int) (exprValue, error) {
+	return stringExprValue(bs.stringSet.Value[i]), nil
+}
+
+func (bs stringSetProxyValue) setValueAt(i int, newVal exprValue) {
+	if str, isStr := newVal.(stringableExprValue); isStr {
+		bs.stringSet.Value[i] = str.asString()
+	}
+}
+
+func (bs stringSetProxyValue) deleteValueAt(idx int) {
+	newList := append([]string{}, bs.stringSet.Value[:idx]...)
+	newList = append(newList, bs.stringSet.Value[idx+1:]...)
+	bs.stringSet = &types.AttributeValueMemberSS{Value: newList}
+}
+
+type numberSetProxyValue struct {
+	numberSet *types.AttributeValueMemberNS
+}
+
+func (bs numberSetProxyValue) asGoValue() any {
+	panic("TODO")
+}
+
+func (bs numberSetProxyValue) asAttributeValue() types.AttributeValue {
+	return bs.numberSet
+}
+
+func (bs numberSetProxyValue) len() int {
+	return len(bs.numberSet.Value)
+}
+
+func (bs numberSetProxyValue) valueAt(i int) (exprValue, error) {
+	fs, _, err := big.ParseFloat(bs.numberSet.Value[i], 10, 63, big.ToNearestEven)
+	if err != nil {
+		return nil, err
+	}
+
+	return bigNumExprValue{fs}, nil
+}
+
+func (bs numberSetProxyValue) setValueAt(i int, newVal exprValue) {
+	if str, isStr := newVal.(numberableExprValue); isStr {
+		bs.numberSet.Value[i] = str.asBigFloat().String()
+	}
+}
+
+func (bs numberSetProxyValue) deleteValueAt(idx int) {
+	newList := append([]string{}, bs.numberSet.Value[:idx]...)
+	newList = append(newList, bs.numberSet.Value[idx+1:]...)
+	bs.numberSet = &types.AttributeValueMemberNS{Value: newList}
+}

--- a/internal/dynamo-browse/models/queryexpr/values.go
+++ b/internal/dynamo-browse/models/queryexpr/values.go
@@ -16,31 +16,7 @@ func (a *astLiteralValue) evalToIR(ctx *evalContext, info *models.TableInfo) (ir
 	return irValue{value: v}, nil
 }
 
-//func (a *astLiteralValue) dynamoValue() (types.AttributeValue, error) {
-//	if a == nil {
-//		return nil, nil
-//	}
-//
-//	goValue, err := a.goValue()
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	switch v := goValue.(type) {
-//	case string:
-//		return &types.AttributeValueMemberS{Value: v}, nil
-//	case int64:
-//		return &types.AttributeValueMemberN{Value: strconv.FormatInt(v, 10)}, nil
-//	}
-//
-//	return nil, errors.New("unrecognised type")
-//}
-
 func (a *astLiteralValue) exprValue() (exprValue, error) {
-	//if a == nil {
-	//	return nil, nil
-	//}
-
 	switch {
 	case a.StringVal != nil:
 		s, err := strconv.Unquote(*a.StringVal)

--- a/internal/dynamo-browse/models/queryexpr/values.go
+++ b/internal/dynamo-browse/models/queryexpr/values.go
@@ -5,42 +5,41 @@ import (
 	"github.com/lmika/audax/internal/dynamo-browse/models"
 	"strconv"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/pkg/errors"
 )
 
 func (a *astLiteralValue) evalToIR(ctx *evalContext, info *models.TableInfo) (irAtom, error) {
-	v, err := a.goValue()
+	v, err := a.exprValue()
 	if err != nil {
 		return nil, err
 	}
 	return irValue{value: v}, nil
 }
 
-func (a *astLiteralValue) dynamoValue() (types.AttributeValue, error) {
-	if a == nil {
-		return nil, nil
-	}
+//func (a *astLiteralValue) dynamoValue() (types.AttributeValue, error) {
+//	if a == nil {
+//		return nil, nil
+//	}
+//
+//	goValue, err := a.goValue()
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	switch v := goValue.(type) {
+//	case string:
+//		return &types.AttributeValueMemberS{Value: v}, nil
+//	case int64:
+//		return &types.AttributeValueMemberN{Value: strconv.FormatInt(v, 10)}, nil
+//	}
+//
+//	return nil, errors.New("unrecognised type")
+//}
 
-	goValue, err := a.goValue()
-	if err != nil {
-		return nil, err
-	}
-
-	switch v := goValue.(type) {
-	case string:
-		return &types.AttributeValueMemberS{Value: v}, nil
-	case int64:
-		return &types.AttributeValueMemberN{Value: strconv.FormatInt(v, 10)}, nil
-	}
-
-	return nil, errors.New("unrecognised type")
-}
-
-func (a *astLiteralValue) goValue() (any, error) {
-	if a == nil {
-		return nil, nil
-	}
+func (a *astLiteralValue) exprValue() (exprValue, error) {
+	//if a == nil {
+	//	return nil, nil
+	//}
 
 	switch {
 	case a.StringVal != nil:
@@ -48,13 +47,13 @@ func (a *astLiteralValue) goValue() (any, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot unquote string")
 		}
-		return s, nil
+		return stringExprValue(s), nil
 	case a.IntVal != nil:
-		return *a.IntVal, nil
+		return int64ExprValue(*a.IntVal), nil
 	case a.TrueBoolValue:
-		return true, nil
+		return boolExprValue(true), nil
 	case a.FalseBoolValue:
-		return false, nil
+		return boolExprValue(false), nil
 	}
 	return nil, errors.New("unrecognised type")
 }
@@ -78,17 +77,17 @@ func (a *astLiteralValue) String() string {
 }
 
 type irValue struct {
-	value any
+	value exprValue
 }
 
 func (i irValue) calcQueryForScan(info *models.TableInfo) (expression.ConditionBuilder, error) {
 	return expression.ConditionBuilder{}, NodeCannotBeConvertedToQueryError{}
 }
 
-func (i irValue) goValue() any {
+func (i irValue) exprValue() exprValue {
 	return i.value
 }
 
 func (a irValue) calcOperand(info *models.TableInfo) expression.OperandBuilder {
-	return expression.Value(a.goValue())
+	return expression.Value(a.value.asGoValue())
 }

--- a/internal/dynamo-browse/services/scriptmanager/iface.go
+++ b/internal/dynamo-browse/services/scriptmanager/iface.go
@@ -32,6 +32,7 @@ type SessionService interface {
 
 type QueryOptions struct {
 	TableName         string
+	IndexName         string
 	NamePlaceholders  map[string]string
 	ValuePlaceholders map[string]types.AttributeValue
 }

--- a/internal/dynamo-browse/services/scriptmanager/modsession.go
+++ b/internal/dynamo-browse/services/scriptmanager/modsession.go
@@ -44,6 +44,11 @@ func (um *sessionModule) query(ctx context.Context, args ...object.Object) objec
 			}
 		}
 
+		// Index name
+		if val, isStr := objMap.Get("index").(*object.String); isStr {
+			options.IndexName = val.Value()
+		}
+
 		// Placeholders
 		if argsVal, isArgsValMap := objMap.Get("args").(*object.Map); isArgsValMap {
 			options.NamePlaceholders = make(map[string]string)

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -144,6 +144,8 @@ func NewModel(
 						itemType = models.BoolItemType
 					case "-NULL":
 						itemType = models.NullItemType
+					case "-TO":
+						itemType = models.ExprValueItemType
 					default:
 						return events.Error(errors.New("unrecognised item type"))
 					}

--- a/test/cmd/load-test-table/main.go
+++ b/test/cmd/load-test-table/main.go
@@ -91,10 +91,14 @@ func main() {
 		}
 	}
 
-	key := gofakeit.UUID()
+	var key = gofakeit.UUID()
 	for i := 0; i < totalItems; i++ {
+		if i%50 == 0 {
+			key = gofakeit.UUID()
+		}
 		if err := tableService.Put(ctx, inventoryTableInfo, models.Item{
 			"pk":   &types.AttributeValueMemberS{Value: key},
+			"sk":   &types.AttributeValueMemberN{Value: fmt.Sprint(i % 50)},
 			"uuid": &types.AttributeValueMemberS{Value: gofakeit.UUID()},
 		}); err != nil {
 			log.Fatalln(err)


### PR DESCRIPTION
- Added the `between` operator to query expressions.
- Added the `using` query expression suffix to specify which index to query (or force a scan).  This is required if query planning has found multiple indices that can potentially be used.
- Rewrote the types of the query expressions to allow for functions to be defined once, and be useful in queries that result in DynamoDB queries, and evaluation.
- Added some test functions around time and summing numbers.
- Fixed a bug in the `del-attr` which was not honouring marked rows in a similar way to `set-attr`: it was only deleting attributes from the first row.
- Added the `-to` type flag to `set-attr` which will set the attribute to the value of a query expression.