### PR TITLE
Added the "export -all" switch

### DIFF
--- a/cmd/dynamo-browse/main.go
+++ b/cmd/dynamo-browse/main.go
@@ -108,7 +108,7 @@ func main() {
 	tableReadController := controllers.NewTableReadController(state, tableService, workspaceService, itemRendererService, jobsController, inputHistoryService, eventBus, *flagTable)
 	tableWriteController := controllers.NewTableWriteController(state, tableService, jobsController, tableReadController, settingStore)
 	columnsController := controllers.NewColumnsController(eventBus)
-	exportController := controllers.NewExportController(state, columnsController)
+	exportController := controllers.NewExportController(state, tableService, jobsController, columnsController)
 	settingsController := controllers.NewSettingsController(settingStore, eventBus)
 	keyBindings := keybindings.Default()
 	scriptController := controllers.NewScriptController(scriptManagerService, tableReadController, settingsController, eventBus)

--- a/internal/common/sliceutils/map.go
+++ b/internal/common/sliceutils/map.go
@@ -9,6 +9,14 @@ func All[T any](ts []T, predicate func(t T) bool) bool {
 	return true
 }
 
+func Generate[U any](from, to int, fn func(t int) U) []U {
+	us := make([]U, to-from+1)
+	for i := from; i <= to; i++ {
+		us[i-from] = fn(i)
+	}
+	return us
+}
+
 func Map[T, U any](ts []T, fn func(t T) U) []U {
 	us := make([]U, len(ts))
 	for i, t := range ts {

--- a/internal/dynamo-browse/controllers/export.go
+++ b/internal/dynamo-browse/controllers/export.go
@@ -1,21 +1,26 @@
 package controllers
 
 import (
+	"context"
 	"encoding/csv"
+	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lmika/dynamo-browse/internal/common/ui/events"
 	"github.com/lmika/dynamo-browse/internal/dynamo-browse/models/attrutils"
+	"github.com/lmika/dynamo-browse/internal/dynamo-browse/services/jobs"
 	"github.com/pkg/errors"
 	"os"
 )
 
 type ExportController struct {
-	state   *State
-	columns *ColumnsController
+	state         *State
+	tableService  TableReadService
+	jobController *JobsController
+	columns       *ColumnsController
 }
 
-func NewExportController(state *State, columns *ColumnsController) *ExportController {
-	return &ExportController{state, columns}
+func NewExportController(state *State, tableService TableReadService, jobsController *JobsController, columns *ColumnsController) *ExportController {
+	return &ExportController{state, tableService, jobsController, columns}
 }
 
 func (c *ExportController) ExportCSV(filename string) tea.Msg {
@@ -54,4 +59,60 @@ func (c *ExportController) ExportCSV(filename string) tea.Msg {
 	}
 
 	return nil
+}
+
+func (c *ExportController) ExportAllCSV(ctx context.Context, filename string) tea.Msg {
+	resultSet := c.state.ResultSet()
+	if resultSet == nil {
+		return events.Error(errors.New("no result set"))
+	}
+
+	return NewJob(c.jobController, fmt.Sprintf("Exporting to %v…", filename), func(ctx context.Context) (int, error) {
+		f, err := os.Create(filename)
+		if err != nil {
+			return 0, errors.Wrapf(err, "cannot export to '%v'", filename)
+		}
+		defer f.Close()
+
+		cw := csv.NewWriter(f)
+		defer cw.Flush()
+
+		columns := c.columns.Columns().VisibleColumns()
+
+		colNames := make([]string, len(columns))
+		for i, c := range columns {
+			colNames[i] = c.Name
+		}
+		if err := cw.Write(colNames); err != nil {
+			return 0, errors.Wrapf(err, "cannot export to '%v'", filename)
+		}
+
+		totalRows := 0
+		row := make([]string, len(columns))
+		for {
+			for _, item := range resultSet.Items() {
+				for i, col := range columns {
+					row[i], _ = attrutils.AttributeToString(col.Evaluator.EvaluateForItem(item))
+				}
+				if err := cw.Write(row); err != nil {
+					return 0, errors.Wrapf(err, "cannot export to '%v'", filename)
+				}
+			}
+			totalRows += len(resultSet.Items())
+
+			if !resultSet.HasNextPage() {
+				break
+			}
+
+			jobs.PostUpdate(ctx, fmt.Sprintf("exported %d items", totalRows))
+			resultSet, err = c.tableService.NextPage(ctx, resultSet)
+			if err != nil {
+				return 0, errors.Wrapf(err, "cannot get next page while exporting to '%v'", filename)
+			}
+		}
+
+		return totalRows, nil
+	}).OnDone(func(rows int) tea.Msg {
+		return events.StatusMsg(applyToN("Exported ", rows, "item", "items", " to "+filename))
+	}).Submit()
 }

--- a/internal/dynamo-browse/controllers/jobbuilder.go
+++ b/internal/dynamo-browse/controllers/jobbuilder.go
@@ -51,6 +51,9 @@ func (jb JobBuilder[T]) executeJob(ctx context.Context) tea.Msg {
 	if jb.onEither != nil {
 		return jb.onEither(res, err)
 	} else if err == nil {
+		if jb.onDone == nil {
+			return nil
+		}
 		return jb.onDone(res)
 	} else {
 		if jb.onErr != nil {

--- a/internal/dynamo-browse/controllers/tableread.go
+++ b/internal/dynamo-browse/controllers/tableread.go
@@ -377,7 +377,7 @@ func (c *TableReadController) NextPage() tea.Msg {
 	resultSet := c.state.ResultSet()
 	if resultSet == nil {
 		return events.StatusMsg("Result-set is nil")
-	} else if resultSet.LastEvaluatedKey == nil {
+	} else if !resultSet.HasNextPage() {
 		return events.StatusMsg("No more results")
 	}
 	currentFilter := c.state.filter

--- a/internal/dynamo-browse/controllers/tableread_test.go
+++ b/internal/dynamo-browse/controllers/tableread_test.go
@@ -89,7 +89,7 @@ func TestTableReadController_Query(t *testing.T) {
 
 		invokeCommand(t, srv.readController.Init())
 		invokeCommandWithPrompts(t, srv.readController.PromptForQuery(), `pk ^= "abc"`)
-		invokeCommand(t, srv.exportController.ExportCSV(tempFile))
+		invokeCommand(t, srv.exportController.ExportCSV(tempFile, controllers.ExportOptions{}))
 
 		bts, err := os.ReadFile(tempFile)
 		assert.NoError(t, err)
@@ -107,7 +107,7 @@ func TestTableReadController_Query(t *testing.T) {
 
 		invokeCommand(t, srv.readController.Init())
 		invokeCommandWithPrompts(t, srv.readController.PromptForQuery(), `alpha = "This is some value"`)
-		invokeCommand(t, srv.exportController.ExportCSV(tempFile))
+		invokeCommand(t, srv.exportController.ExportCSV(tempFile, controllers.ExportOptions{}))
 
 		bts, err := os.ReadFile(tempFile)
 		assert.NoError(t, err)
@@ -124,7 +124,7 @@ func TestTableReadController_Query(t *testing.T) {
 		tempFile := tempFile(t)
 
 		invokeCommandExpectingError(t, srv.readController.Init())
-		invokeCommandExpectingError(t, srv.exportController.ExportCSV(tempFile))
+		invokeCommandExpectingError(t, srv.exportController.ExportCSV(tempFile, controllers.ExportOptions{}))
 	})
 }
 

--- a/internal/dynamo-browse/controllers/tablewrite_test.go
+++ b/internal/dynamo-browse/controllers/tablewrite_test.go
@@ -621,7 +621,7 @@ func newService(t *testing.T, cfg serviceConfig) *services {
 	writeController := controllers.NewTableWriteController(state, service, jobsController, readController, settingStore)
 	settingsController := controllers.NewSettingsController(settingStore, eventBus)
 	columnsController := controllers.NewColumnsController(eventBus)
-	exportController := controllers.NewExportController(state, columnsController)
+	exportController := controllers.NewExportController(state, service, jobsController, columnsController)
 	scriptController := controllers.NewScriptController(scriptService, readController, settingsController, eventBus)
 
 	commandController := commandctrl.NewCommandController(inputHistoryService)

--- a/internal/dynamo-browse/models/models.go
+++ b/internal/dynamo-browse/models/models.go
@@ -135,3 +135,7 @@ func (rs *ResultSet) RefreshColumns() {
 
 	rs.columns = columns
 }
+
+func (rs *ResultSet) HasNextPage() bool {
+	return rs.LastEvaluatedKey != nil
+}

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"context"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lmika/dynamo-browse/internal/common/ui/commandctrl"
@@ -100,19 +99,17 @@ func NewModel(
 				}
 			},
 			"export": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
-				var exportAll = false
-				if len(args) == 2 && args[0] == "-all" {
-					exportAll = true
-					args = args[1:]
-				}
-
 				if len(args) == 0 {
 					return events.Error(errors.New("expected filename"))
 				}
-				if exportAll {
-					return exportController.ExportAllCSV(context.Background(), args[0])
+
+				opts := controllers.ExportOptions{}
+				if len(args) == 2 && args[0] == "-all" {
+					opts.AllResults = true
+					args = args[1:]
 				}
-				return exportController.ExportCSV(args[0])
+
+				return exportController.ExportCSV(args[0], opts)
 			},
 			"mark": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
 				var markOp = controllers.MarkOpMark

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lmika/dynamo-browse/internal/common/ui/commandctrl"
@@ -99,8 +100,17 @@ func NewModel(
 				}
 			},
 			"export": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
+				var exportAll = false
+				if len(args) == 2 && args[0] == "-all" {
+					exportAll = true
+					args = args[1:]
+				}
+
 				if len(args) == 0 {
 					return events.Error(errors.New("expected filename"))
+				}
+				if exportAll {
+					return exportController.ExportAllCSV(context.Background(), args[0])
 				}
 				return exportController.ExportCSV(args[0])
 			},


### PR DESCRIPTION
Extended the "export" command with an "-all" flag. When included, all rows of the table matching the query will be exported to CSV.